### PR TITLE
Fix Fatal Exception: negative sizes are not supported in the flow layout

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -669,7 +669,13 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     }
     
     CGFloat width = (CGRectGetWidth(self.view.frame) - 2.0 * (numberOfColumns - 1)) / numberOfColumns;
-    
+
+    // Fatal Exception: NSInternalInconsistencyException negative sizes are not supported in the flow layout
+    // The width and height of the specified item. Both values must be greater than 0.
+    if (width <= 0) {
+        width = 1.0f;
+    }
+
     return CGSizeMake(width, width);
 }
 


### PR DESCRIPTION
Applied this fix from the upstream PR: https://github.com/questbeat/QBImagePicker/pull/216.

MAGENTACLD-3155